### PR TITLE
Some updates

### DIFF
--- a/cli/commands/f/list.js
+++ b/cli/commands/f/list.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const Command = require('cmnd').Command;
+const path = require('path');
+const fs = require('fs');
+const async = require('async');
+const APIResource = require('api-res');
+const table = require('text-table');
+const Credentials = require('../../credentials.js');
+
+class FListCommand extends Command {
+
+  constructor() {
+
+    super('f', 'list');
+
+  }
+
+  help() {
+
+    return {
+      description: 'List your functions'
+    };
+
+  }
+
+  run(params, callback) {
+
+    let host = 'api.polybit.com';
+    let port = 443;
+
+    let hostname = (params.flags.h && params.flags.h[0]) || '';
+    let matches = hostname.match(/^(https?:\/\/)?(.*?)(:\d+)?$/);
+
+    if (hostname && matches) {
+      host = matches[2];
+      port = parseInt((matches[3] || '').substr(1) || (hostname.indexOf('https') === 0 ? 443 : 80));
+    }
+
+    let resource = new APIResource(host, port);
+    resource.authorize(Credentials.read('ACCESS_TOKEN'));
+
+    return resource.request('v1/functions').index({}, (err, response) => {
+      if (err) {
+        return callback(err);
+      }
+
+      if (response.data.length === 0) {
+        return callback(null, 'You have no functions yet.' +
+          ' Run stdlib f:new to create your first function');
+      }
+
+      const functions = response.data.map(v => [`f ${v.command}`, v.url]);
+      functions.unshift(['Command', 'HTTPS (POST)']);
+
+      const result = table(functions);
+
+      callback(null, result);
+    });
+  }
+}
+
+module.exports = FListCommand;

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = {
             }
           }
 
-          callback(null, response);
+          callback(null, response.toString());
 
         });
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "api-res": "0.0.4",
     "async": "^2.0.1",
     "cmnd": "~0.1.1",
-    "inquirer": "~0.11.3"
+    "inquirer": "~0.11.3",
+    "text-table": "^0.2.0"
   }
 }


### PR DESCRIPTION
When the server returned an error response the `response` variable
was passed to the `callback` function as a `Buffer` the message
printed on screen was `<Buffer ...>`.

This commit fixes it by converting the response into a string by
using the `.toString()` method.

Before this commit:

```
txgruppi@txgruppi-pro15:~/c/g/t/stdlib ±master$ stdlib f txgruppi/dev/hr
<Buffer 45 72 72 6f 72 3a 20 52 65 71 75 65 73 74 20 74 69 6d 65 64 20 6f 75 74>
```

After this commit:

```
txgruppi@txgruppi-pro15:~/c/g/t/stdlib ±master$ stdlib f txgruppi/dev/hr
Error: missing the first argument
```

---

Added the command f:list

Added the command to list the functions of the current user.

```
txgruppi@txgruppi-pro15:~/c/g/t/stdlib ±master$ node cli/bin.js f:list
Command            HTTPS (POST)
f txgruppi/dev/hr  https://f.stdlib.com/txgruppi/dev/hr
```
