### PR TITLE
fixed crash on Node.js v4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const http = require('http');
 const https = require('https');
 


### PR DESCRIPTION
There was a following issue in console:
"SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode"
