### PR TITLE
Fixed an error in the README tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ In your main service directory to add it, and use it like so:
 ```javascript
 module.exports = (params, callback) => {
 
-	return callback(null, params.args[1] + params.args[2]);
+	return callback(null, parseInt(params.args[0]) + parseInt(params.args[1]));
 
 };
 ```


### PR DESCRIPTION
While going through the README tutorials, I noticed an error.

It says that running `f ./add 1 2` should return `3`, but as it stands, it returns `2undefined`, because the `params.args` indexes used are wrong.

They also return strings - they need to be casted as ints, otherwise you get `12` (`'1' + '2' == '12'`).