### PR TITLE
Support sending files from the command line

### DIFF
--- a/cli/commands/__nomethod__.js
+++ b/cli/commands/__nomethod__.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Command = require('cmnd').Command;
+const fs = require('fs');
 const lib = require('lib');
 const path = require('path');
 
@@ -64,7 +65,12 @@ class __nomethod__Command extends Command {
 
     try {
       process.env = env();
-      lib[params.name](...args, kwargs, cb);
+      if (params.flags.f && params.flags.f.length === 1) {
+        const buffer = fs.readFileSync(params.flags.f[0]);
+        lib[params.name](buffer, cb);
+      } else {
+        lib[params.name](...args, kwargs, cb);
+      }
     } catch(e) {
       return callback(e);
     }


### PR DESCRIPTION
I’m not sure if [this feature](https://github.com/stdlib/f#sending-files) is still supported. The [`lib-node` client supports sending file](https://github.com/stdlib/lib-node/blob/916b4d7bbc4928f8703e6fce2b88bedae392a4c7/lib/parse.js#L8), but that functionality isn’t exposed in the command line.