### PR TITLE
Allow to get the ACCESS_TOKEN from an environment variable

### DIFF
--- a/cli/credentials.js
+++ b/cli/credentials.js
@@ -29,24 +29,30 @@ function findPath(maxDepth) {
 
 function readCredentials() {
 
-  let cred = '';
-  let stdlibPath = findPath();
+  if(process.env.STDLIB_ACCESS_TOKEN) {
+    return {
+      ACCESS_TOKEN: process.env.STDLIB_ACCESS_TOKEN
+    };
+  } else {
+    let cred = '';
+    let stdlibPath = findPath();
 
-  if (!stdlibPath) {
-    throw new Error(`Please initialize stdlib in directory tree`);
+    if (!stdlibPath) {
+      throw new Error(`Please initialize stdlib in directory tree or set STDLIB_ACCESS_TOKEN as environment variable`);
+    }
+
+    cred = fs.readFileSync(stdlibPath).toString();
+
+    return cred
+      .split('\n')
+      .filter(v => v)
+      .map(l => l.split('='))
+      .reduce((p, c) => {
+        p[c[0]] = c[1];
+
+        return p;
+      }, {});
   }
-
-  cred = fs.readFileSync(stdlibPath).toString();
-
-  return cred
-    .split('\n')
-    .filter(v => v)
-    .map(l => l.split('='))
-    .reduce((p, c) => {
-      p[c[0]] = process.env[c[0]] || c[1];
-
-      return p;
-    }, {});
 }
 
 function writeCredentials(obj, pathname) {

--- a/cli/credentials.js
+++ b/cli/credentials.js
@@ -29,10 +29,16 @@ function findPath(maxDepth) {
 
 function readCredentials() {
 
-  if(process.env.STDLIB_ACCESS_TOKEN) {
-    return {
-      ACCESS_TOKEN: process.env.STDLIB_ACCESS_TOKEN
-    };
+  if (process.env.hasOwnProperty('STDLIB_ACCESS_TOKEN')) {
+    let prefix = 'STDLIB_';
+
+    return Object.keys(process.env)
+      .filter(key => key.indexOf(prefix) === 0)
+      .map(key => key.substr(prefix.length))
+      .reduce((obj, key) => {
+        obj[key] = process.env[prefix + key];
+        return obj;
+      }, {});
   } else {
     let cred = '';
     let stdlibPath = findPath();

--- a/cli/credentials.js
+++ b/cli/credentials.js
@@ -42,8 +42,11 @@ function readCredentials() {
     .split('\n')
     .filter(v => v)
     .map(l => l.split('='))
-    .reduce((p, c) => { return (p[c[0]] = c[1]), p; }, {})
+    .reduce((p, c) => {
+      p[c[0]] = process.env[c[0]] || c[1];
 
+      return p;
+    }, {});
 }
 
 function writeCredentials(obj, pathname) {


### PR DESCRIPTION
From #40 

It allows to use environment variables to replace variables from `.stdlib`.
It's possible to set the `ACCESS_TOKEN` directly in an environment variable called *ACCESS_TOKEN*.