### PR TITLE
Add login flags documentation

### DIFF
--- a/cli/commands/login.js
+++ b/cli/commands/login.js
@@ -19,7 +19,11 @@ class PolyLoginCommand extends Command {
   help() {
 
     return {
-      description: 'Logs in to StdLib in this directory'
+      description: 'Logs in to StdLib in this directory',
+      vflags: {
+        email: 'E-Mail',
+        password: 'Password'
+      }
     };
 
   }


### PR DESCRIPTION
Hi there!
I've noticed that the `login` command has two optional flags, email and password, which are not documented. Here's a quick PR to fix it: if you have a better description for the flags please let me know, happy to change them!

Cheers 🙆 