### PR TITLE
Fix `context.service.identifier` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ module.exports = (a = 0, b = 0, callback) => {
 const lib = require('lib');
 
 module.exports = (a = 0, b = 0, context, callback) => {
-  return lib[`${context.identifier}.add`](a, b, (err, result) => {
+  return lib[`${context.service.identifier}.add`](a, b, (err, result) => {
     callback(err, result * 2);
   });
 };
@@ -232,8 +232,8 @@ module.exports = (a = 0, b = 0, context, callback) => {
 
 In this case, calling `lib .add 1 2` will return `3` and `lib .add_double 1 2`
 will return `6`. The `context` magic parameter is used for its
-`context.identifier` property, which will return the string `"user.service[@local]"`
-in the case of local execution, `"user.service[@ENV]"` when deployed to an
+`context.service.identifier` property, which will return the string `"your-username.your-service[@local]"`
+in the case of local execution, `"your-username.your-service[@ENV]"` when deployed to an
 environment or release (where `ENV` is your environment name or semver).
 
 Note that `lib .add --a 1 --b 2` and
@@ -245,7 +245,7 @@ via an object in the `add_double` function:
 const lib = require('lib');
 
 module.exports = (a = 0, b = 0, context, callback) => {
-  return lib[`${context.identifier}.add`]({a: a, b: b}, (err, result) => {
+  return lib[`${context.service.identifier}.add`]({a: a, b: b}, (err, result) => {
     callback(err, result * 2);
   });
 };


### PR DESCRIPTION
Hello, following the instructions in the "Getting Started" section of the README.md file, I noticed a mistake:
`context.identifier` does not work, I think it should be `context.service.identifier`.

This problem is also mentioned here https://github.com/stdlib/lib/issues/62.

Also, to be consistent with the rest of the page I renamed this:
`"user.service[@local]"` => `"your-username.your-service[@local]"`

By the way I'm the creator of bestof.js.org, where `stdlib` project is mentioned under the "microservices" tag, as you can see here:
https://bestof.js.org/tags/microservice
Since I am a fan of the microservices architecture, I may use `stdlib` in bestof.js.org project.

![image](https://user-images.githubusercontent.com/5546996/29492074-07116220-85ab-11e7-9964-7a1536dd1217.png)

Thank you for your hard word!