### PR TITLE
Removed dup source field in package.json

### DIFF
--- a/cli/commands/source/fork.js
+++ b/cli/commands/source/fork.js
@@ -184,7 +184,6 @@ class SourceForkCommand extends Command {
         pkg.stdlib.name = serviceName;
         pkg.stdlib.build = 'faaslang';
         pkg.stdlib.publish = true;
-        pkg.source = sourceName;
 
         fs.writeFileSync(path.join(servicePath, 'package.json'), JSON.stringify(pkg, null, 2));
 


### PR DESCRIPTION
We were currently tracking source twice in package.json. Once in the stdlib field and once at the top level of package.json. I removed the top level one. 