### PR TITLE
Creates /tmp/stdlib in lib get if it does not exist, makes legacy a special case in local testing

### DIFF
--- a/cli/commands/__nomethod__.js
+++ b/cli/commands/__nomethod__.js
@@ -149,7 +149,7 @@ class __nomethod__Command extends Command {
           return callback(new Error('Invalid "env.json" in this directory, your JSON syntax is likely malformed.'));
         }
       }
-      if (pkg.stdlib.build === 'faaslang') {
+      if (pkg.stdlib.build !== 'legacy') {
         gateway = new LocalGateway({debug: debug});
         let fp = new FunctionParser();
         try {

--- a/cli/commands/get.js
+++ b/cli/commands/get.js
@@ -126,6 +126,8 @@ class GetCommand extends Command {
         }
       }
 
+      !fs.existsSync('/tmp') && fs.mkdirSync('/tmp');
+      !fs.existsSync('/tmp/stdlib') && fs.mkdirSync('/tmp/stdlib', 0o777);
       let tmpPath = `/tmp/${service.replace(/\//g, '.')}.tgz`;
       try {
         fs.writeFileSync(tmpPath, response);

--- a/cli/commands/get.js
+++ b/cli/commands/get.js
@@ -128,7 +128,7 @@ class GetCommand extends Command {
 
       !fs.existsSync('/tmp') && fs.mkdirSync('/tmp');
       !fs.existsSync('/tmp/stdlib') && fs.mkdirSync('/tmp/stdlib', 0o777);
-      let tmpPath = `/tmp/${service.replace(/\//g, '.')}.tgz`;
+      let tmpPath = `/tmp/stdlib/${service.replace(/\//g, '.')}.tgz`;
       try {
         fs.writeFileSync(tmpPath, response);
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib.cli",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "StdLib: Standard Library for APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Mirroring behavior in `lib up`, should fix #162 