### PR TITLE
Hotfix build

### DIFF
--- a/cli/commands/up.js
+++ b/cli/commands/up.js
@@ -188,9 +188,11 @@ class UpCommand extends Command {
             ? `${pkg.stdlib ? pkg.stdlib.name : pkg.name}@${pkg.version}`
             : `${pkg.stdlib ? pkg.stdlib.name : pkg.name}@${environment}`;
 
+          let build = pkg.stdlib ? pkg.stdlib.build : pkg.build;
+
           return resource
             .request(endpoint)
-            .headers({'X-Stdlib-Build': pkg.build || pkg.stdlib.build || ''})
+            .headers({'X-Stdlib-Build': build || ''})
             .stream(
               'POST',
               result,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib.cli",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "Command Line Tools for Standard Library - stdlib.com",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The reason why I didn't go with the fix of defaulting to and empty pkg.stdlib field is I have checks like

`let serviceName = pkg.stdlib ? pkg.stdlib.name : pkg.name;`

elsewhere. A refactor to not do this would be pretty easy if wanted.